### PR TITLE
downgrade avro4s to stable 1.6.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,13 @@ name := "lambdaconf-beam"
 
 scalaVersion := "2.11.11"
 
-// latest snapshot for scala 2.11
-val avro4s = ProjectRef(uri("https://github.com/kanterov/avro4s.git"), "avro4s-core")
-
 libraryDependencies ++= Seq(
   "com.spotify" %% "scio-core" % "0.3.1",
   "com.spotify" %% "scio-test" % "0.3.1" % "test",
+  "com.sksamuel.avro4s" %% "avro4s-core" % "1.6.4",
   "org.slf4j" % "slf4j-nop" % "1.7.25",
   "org.typelevel" %% "discipline" % "0.7.3" % "test",
   "org.typelevel" %% "cats-kernel-laws" % "0.9.0" % "test"
 )
-
-dependsOn(avro4s)
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)


### PR DESCRIPTION
I got this error for the 1.6.5 snapshot, as did @szimano

```
➜  lambdaconf-2017-bigdata git:(master) sbt "runMain us.lambdaconf.HelloWorld"
[warn] Executing in batch mode.
[warn]   For better performance, hit [ENTER] to switch to interactive mode, or
[warn]   consider launching sbt without any commands, or explicitly passing 'shell'
[info] Loading project definition from /Users/jon/IdeaProjects/lambdaconf-2017-bigdata/project/project
[info] Updating {file:/Users/jon/IdeaProjects/lambdaconf-2017-bigdata/project/project/}lambdaconf-2017-bigdata-build-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Loading project definition from /Users/jon/IdeaProjects/lambdaconf-2017-bigdata/project
[info] Loading project definition from /Users/jon/.sbt/0.13/staging/09342cdc8d0cbfd0031d/avro4s/project
[info] Set current project to lambdaconf-beam (in build file:/Users/jon/IdeaProjects/lambdaconf-2017-bigdata/)
[info] Updating lambdaconf-2017-bigdata
[info] Resolved lambdaconf-2017-bigdata dependencies
coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
  com.sksamuel.avro4s:avro4s-core_2.11:1.6.5-SNAPSHOT:
    not found:
      /Users/jon/.ivy2/local/com.sksamuel.avro4s/avro4s-core_2.11/1.6.5-SNAPSHOT/ivys/ivy.xml
      https://repo1.maven.org/maven2/com/sksamuel/avro4s/avro4s-core_2.11/1.6.5-SNAPSHOT/avro4s-core_2.11-1.6.5-SNAPSHOT.pom
[error] (lambdaconf-2017-bigdata/*:coursierResolution) coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[error]   com.sksamuel.avro4s:avro4s-core_2.11:1.6.5-SNAPSHOT:
[error]     not found:
[error]       /Users/jon/.ivy2/local/com.sksamuel.avro4s/avro4s-core_2.11/1.6.5-SNAPSHOT/ivys/ivy.xml
[error]       https://repo1.maven.org/maven2/com/sksamuel/avro4s/avro4s-core_2.11/1.6.5-SNAPSHOT/avro4s-core_2.11-1.6.5-SNAPSHOT.pom
[error] Total time: 3 s, completed May 26, 2017 7:40:26 AM
```

with these changes i got

```
--- LOTS OF MAVEN INSTALLS REDACTED --

[info] Fetched artifacts of lambdaconf-2017-bigdata
[info] Compiling 1 Scala source to /Users/jon/IdeaProjects/lambdaconf-2017-bigdata/target/scala-2.11/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.11.11. Compiling...
[info]   Compilation completed in 7.264 s
[info] Running us.lambdaconf.HelloWorld 
Hello World
[success] Total time: 497 s, completed May 26, 2017 7:59:52 AM
